### PR TITLE
Few corrections in Polish translation

### DIFF
--- a/app/locale/lang/polish.json
+++ b/app/locale/lang/polish.json
@@ -1,6 +1,6 @@
 {
-  "achievements" : "Osiągnięcia",
-  "perfectGame" : "Skończone gry",
+  "achievements" : "Osiągnięć",
+  "perfectGame" : "Skończonych gier",
   "completionRate": "Średni procent ukończenia gier",
   "emptyList": "Brak gier",
   "loading": "Wczytywanie",
@@ -8,7 +8,7 @@
   "locked": "Zablokowane",
   "globalStat" : "graczy odblokowało to osiągnięcie",
   "hiddenRemain" : "ukrytych osiągnięć (pozostało)",
-  "revealedOnceUnlocked" : "Szczegóły każdego osiągnięcia będą ujawnione kiedy je zdobędziesz",
+  "revealedOnceUnlocked" : "Szczegóły każdego osiągnięcia zostaną ujawnione kiedy je zdobędziesz",
   "noneUnlocked": "Nie odblokowałeś żadnych osiągnięć",
   "play": "Zacznij grać!",
   "scrollUp" : "Przewiń do góry",


### PR DESCRIPTION
Since this project doesn't support plurals/singulars (yet), i had to change `achievements` and `perfectGame` strings to their plural equivalents. Also i changed one word in `revealedOnceUnlocked`, because in my opinion it just fits better.

Suggestion @xan105
Add support for plurals, it can look like that:

`
{
 "someStringID": {
   "singular": "achievement",
   "plural": "achievements"}
}
`